### PR TITLE
Add /dev/serial/by-id/usb-Dronesmith_Technologies* to serial port lis…

### DIFF
--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -487,6 +487,7 @@ function(px4_add_upload)
 	set(serial_ports)
 	if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux")
 		list(APPEND serial_ports
+			/dev/serial/by-id/usb-Dronesmith_Technologies*
 			/dev/serial/by-id/usb-3D_Robotics*
 			/dev/serial/by-id/usb-The_Autopilot*
 			/dev/serial/by-id/pci-3D_Robotics*


### PR DESCRIPTION
Luci revE2 is on /dev/serial/by-id/usb-3D_Robotics_LUCI_FMU_v1.x_0-if00 but uploader script did not look for that usb serial device
